### PR TITLE
fix: ensure conditional checks for GitHub Pages and Release Please

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  if: github.ref == 'refs/heads/release-please--branches--main'
   build:
+    if: github.ref == 'refs/heads/release-please--branches--main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,6 +32,7 @@ jobs:
           path: '.'
 
   deploy:
+    if: github.ref == 'refs/heads/release-please--branches--main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,8 +10,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  if: github.ref != 'refs/heads/release-please--branches--main'
   release-please:
+    if: github.ref != 'refs/heads/release-please--branches--main'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
This pull request updates the workflow conditions in the GitHub Actions configuration files to ensure that jobs only run on the appropriate branches. The main changes involve moving the branch condition checks from the job level to the correct location within each job definition, improving workflow clarity and correctness.

**Workflow condition updates:**

* Moved the `if: github.ref == 'refs/heads/release-please--branches--main'` condition from the top-level job definition to the `build` job itself in `.github/workflows/deploy-pages.yml`, ensuring the job only runs on the intended branch.
* Added the same branch condition to the `deploy` job in `.github/workflows/deploy-pages.yml` for consistency and correctness.
* Moved the `if: github.ref != 'refs/heads/release-please--branches--main'` condition from the top-level job definition to the `release-please` job itself in `.github/workflows/release-please.yml`, aligning the condition with the job execution.